### PR TITLE
Adapt to Ubuntu 24 update

### DIFF
--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -68,10 +68,7 @@ jobs:
 
     - name: prepare Linux
       if: runner.os == 'Linux' && steps.cache_artefacts.outputs.cache-hit != 'true'
-      run: |
-        sudo apt-get update
-        # sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100
-        # sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100
+      run: sudo apt-get update
     - name: prepare macOS
       if: runner.os == 'macOS' && steps.cache_artefacts.outputs.cache-hit != 'true'
       run: echo noop

--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -70,8 +70,8 @@ jobs:
       if: runner.os == 'Linux' && steps.cache_artefacts.outputs.cache-hit != 'true'
       run: |
         sudo apt-get update
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100
+        # sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100
+        # sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100
     - name: prepare macOS
       if: runner.os == 'macOS' && steps.cache_artefacts.outputs.cache-hit != 'true'
       run: echo noop


### PR DESCRIPTION
it seems that there is no gcc 10 on the new ubuntu, and the default selected version manages to build qmlls, so remove the udpate-alternative calls from the ubuntu setup.