### PR TITLE
Link documentation plugin into qmlls

### DIFF
--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -257,8 +257,15 @@ jobs:
         echo cache_key=${cache_key} >> $GITHUB_OUTPUT
         echo revision=nightly-${cache_key} >> $GITHUB_OUTPUT
 
-        echo unsigned_macos_archive=$(ls weekly_release/qmlls-macos-*-unsigned.zip/qmlls-macos-*-unsigned.zip | head -n 1) >> $GITHUB_OUTPUT
-        echo unsigned_windows_archive=$(ls weekly_release/qmlls-windows-*-unsigned.zip/qmlls-windows-*-unsigned.zip | head -n 1) >> $GITHUB_OUTPUT
+        unsigned_macos_archive="$(ls weekly_release/qmlls-macos-*-unsigned.zip/qmlls-macos-*-unsigned.zip | head -n 1)"
+        unsigned_windows_archive="$(ls weekly_release/qmlls-windows-*-unsigned.zip/qmlls-windows-*-unsigned.zip | head -n 1)"
+
+        echo unsigned_macos_archive=${unsigned_macos_archive} >> $GITHUB_OUTPUT
+        echo unsigned_windows_archive=${unsigned_windows_archive} >> $GITHUB_OUTPUT
+
+        echo Files to be signed: ${unsigned_macos_archive} and ${unsigned_windows_archive}
+        ls -lh ${unsigned_windows_archive}
+        du -lh ${unsigned_macos_archive}
 
     - name: Sign archives
       id: sign-archives

--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -149,15 +149,16 @@ jobs:
         ninja qtdeclarative qtbase qttools
 
     - uses: actions/checkout@v4
+      if: steps.cache_artefacts.outputs.cache-hit != 'true'
       with:
-        path: source
+        path: qmlls-workflow-source
 
     - name: configure and build Qmlls
       if: steps.cache_artefacts.outputs.cache-hit != 'true'
       run:  |
         rm -rf qmlls-build; mkdir qmlls-build
         cd qmlls-build
-        ../qt-build/qtbase/bin/qt-cmake -S ../source -B . -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo ${{ matrix.qmlls_configure_flags }}
+        ../qt-build/qtbase/bin/qt-cmake -S ../qmlls-workflow-source -B . -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo ${{ matrix.qmlls_configure_flags }}
         ninja
 
     - name: Create info file

--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -73,10 +73,6 @@ jobs:
       run: |
         sudo apt-get update
         # try to make more disk space by removing unused things
-        # apt list --installed || true # if more stuff needs to be removed
-        echo List of installed packages:
-        dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -rn
-        pip --list || true # if more stuff needs to be removed
         sudo apt-get purge firefox chromium-browser microsoft-edge-stable google-chrome-stable apache2 mysql-server mysql-common "php*" "ruby*"  || true
         sudo apt-get autoremove || true
         sudo rm -rf /usr/local/lib/android/sdk || true
@@ -176,7 +172,7 @@ jobs:
         rm -rf qmlls-build; mkdir qmlls-build
         cd qmlls-build
         ../qt-build/qtbase/bin/qt-cmake${{ matrix.script_extension }} -S ../qmlls-workflow-source -B . -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo ${{ matrix.qmlls_configure_flags }}
-        ninja -v
+        ninja
 
     - name: Remove Qt Build to save disk space
       if: steps.cache_artefacts.outputs.cache-hit != 'true'
@@ -251,7 +247,7 @@ jobs:
         echo Files to be signed: ${unsigned_macos_archive} and ${unsigned_windows_archive}
         ls -lh ${unsigned_windows_archive} ${unsigned_macos_archive}
 
-    - name: Sign archives for macos
+    - name: Sign archives
       id: sign-archives
       uses: TheQtCompanyRnD/SignArchives@v1
       with:

--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -31,6 +31,7 @@ jobs:
             tools: ccache
             install_cmd: HOMEBREW_NO_INSTALL_CLEANUP=1 brew install
             configure_flags: -- '-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64'
+            qmlls_configure_flags: -DCMAKE_OSX_ARCHITECTURES=x86_64;arm64
             debugging_symbols_extension: .dSYM
             unsigned_suffix: -unsigned
           - name: windows
@@ -58,7 +59,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: artefacts
-        key: no-icu-${{ runner.os }}-${{ steps.artefacts_cache_key.outputs.key }}-artefacts
+        key: ${{ runner.os }}-${{ steps.artefacts_cache_key.outputs.key }}-artefacts
 
     - uses: lukka/get-cmake@latest
       if: steps.cache_artefacts.outputs.cache-hit != 'true'
@@ -113,7 +114,7 @@ jobs:
       run:  |
         git clone https://code.qt.io/qt/qt5.git source
         cd source
-        ./init-repository --module-subset=qtdeclarative
+        ./init-repository --module-subset=qtdeclarative,qttools
 
     - name: update cached repository
       if: steps.cache-repo.outputs.cache-hit == 'true' && steps.cache_artefacts.outputs.cache-hit != 'true'
@@ -130,16 +131,25 @@ jobs:
         cmake -DSYNC_TO_MODULE="qtdeclarative" -DSYNC_TO_BRANCH="dev" -P cmake/QtSynchronizeRepo.cmake
         echo "Using following SHAs: "
         for i in . qtdeclarative qtbase qtimageformats qtlanguageserver qtshadertools qtsvg; do (cd $i; echo "$i: $(git show HEAD -s --format=oneline)";); done;
+        (cd qttools; git checkout dev; git pull; git submodule update;)
 
-    - name: configure and build
+    - name: configure and build Qt
       if: steps.cache_artefacts.outputs.cache-hit != 'true'
       run:  |
-        mkdir build
-        cd build
+        mkdir qt-build
+        cd qt-build
         ../source/configure -force-debug-info -ccache -no-pch -release -static -no-icu \
-          -force-bundled-libs -submodules qtdeclarative -nomake tests -nomake examples \
+          -force-bundled-libs -submodules qtdeclarative,qttools -nomake tests -nomake examples \
           -prefix '${{ runner.temp }}'/install_dir -no-sbom ${{ matrix.configure_flags }}
-        ninja qmlls
+        ninja qtdeclarative qtbase qttools
+
+    - name: configure and build Qmlls
+      if: steps.cache_artefacts.outputs.cache-hit != 'true'
+      run:  |
+        mkdir qmlls-build
+        cd qmlls-build
+        ../qt-build/qtbase/bin/qt-cmake -S .. -B . -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo ${{ matrix.qmlls_configure_flags }}
+        ninja
 
     - name: Create info file
       if: steps.cache_artefacts.outputs.cache-hit != 'true'
@@ -147,26 +157,25 @@ jobs:
         echo -e "commit: $(cd source/qtdeclarative && git rev-parse --short HEAD)\nbuild: $(date +"%Y-%m-%dT%H:%M:%SZ")" \
         > info.txt
 
-    # workarounds because -separate-debug-info is not supported in static builds
     - name: Stripping qmlls binary on linux
       if: matrix.name == 'ubuntu' && steps.cache_artefacts.outputs.cache-hit != 'true'
       run: |
-        objcopy --only-keep-debug ./build/qtbase/bin/qmlls ./build/qtbase/bin/qmlls.dbg
-        strip ./build/qtbase/bin/qmlls
-        objcopy --add-gnu-debuglink=./build/qtbase/bin/qmlls.dbg ./build/qtbase/bin/qmlls
+        objcopy --only-keep-debug ./qmlls-build/qmlls ./qmlls-build/qmlls.dbg
+        strip ./qmlls-build/qmlls
+        objcopy --add-gnu-debuglink=./qmlls-build/qmlls.dbg ./qmlls-build/qmlls
 
     - name: Stripping qmlls binary on mac
       if: matrix.name == 'macos' && steps.cache_artefacts.outputs.cache-hit != 'true'
       run: |
-        dsymutil ./build/qtbase/bin/qmlls -o ./build/qtbase/bin/qmlls.dSYM
-        strip ./build/qtbase/bin/qmlls
+        dsymutil ./qmlls-build/qmlls -o ./qmlls-build/qmlls.dSYM
+        strip ./qmlls-build/qmlls
 
     - name: Zipping debug symbols and executable
       if: steps.cache_artefacts.outputs.cache-hit != 'true'
       run: |
         mkdir artefacts
-        7z a artefacts/${{ steps.artefacts_cache_key.outputs.artefact_basename }}-debugsymbols.zip ./build/qtbase/bin/qmlls${{ matrix.debugging_symbols_extension }} info.txt
-        7z a artefacts/${{ steps.artefacts_cache_key.outputs.artefact_basename }}${{ matrix.unsigned_suffix }}.zip ./build/qtbase/bin/qmlls${{ matrix.executable_extension }} info.txt
+        7z a artefacts/${{ steps.artefacts_cache_key.outputs.artefact_basename }}-debugsymbols.zip ./qmlls-build/qtbase/bin/qmlls${{ matrix.debugging_symbols_extension }} info.txt
+        7z a artefacts/${{ steps.artefacts_cache_key.outputs.artefact_basename }}${{ matrix.unsigned_suffix }}.zip ./qmlls-build/qtbase/bin/qmlls${{ matrix.executable_extension }} info.txt
 
     - name: Upload artefact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -72,7 +72,7 @@ jobs:
       run: |
         sudo apt-get update
         # try to make more disk space by removing unused things
-        rm -rf /usr/local/lib/android/sdk;
+        sudo rm -rf /usr/local/lib/android/sdk
     - name: prepare macOS
       if: runner.os == 'macOS' && steps.cache_artefacts.outputs.cache-hit != 'true'
       run: echo noop

--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -137,15 +137,14 @@ jobs:
         cd qtdeclarative
         git reset --hard origin/dev
         git fetch https://codereview.qt-project.org/qt/qtdeclarative refs/changes/41/617341/4 && git checkout FETCH_HEAD # TODO: remove me once patch got merged
-        cd ../qttools
-        git fetch https://codereview.qt-project.org/qt/qttools refs/changes/33/619233/7 && git checkout FETCH_HEAD # TODO: remove me once patch got merged
+        (cd ../qttools; git checkout dev; git reset --hard origin/dev; git submodule update)
 
     - name: set qtdeclarative to dev and set dependencies via dependencies.yaml
       if: steps.cache_artefacts.outputs.cache-hit != 'true'
       working-directory: source
       run: | 
         cmake -DSYNC_TO_MODULE="qtdeclarative" -DSYNC_TO_BRANCH="dev" -P cmake/QtSynchronizeRepo.cmake
-        (cd qttools; git checkout dev; git pull; git submodule update; git fetch https://codereview.qt-project.org/qt/qttools refs/changes/33/619233/7 && git checkout FETCH_HEAD) # TODO: remove me once patch got merged
+        (cd ../qttools; git checkout dev; git reset --hard origin/dev; git submodule update)
         
         (cd qtdeclarative; git fetch https://codereview.qt-project.org/qt/qtdeclarative refs/changes/41/617341/4 && git checkout FETCH_HEAD) # TODO: remove me once patch got merged
         echo "Using following SHAs: "
@@ -255,18 +254,10 @@ jobs:
         ls -lh ${unsigned_windows_archive} ${unsigned_macos_archive}
 
     - name: Sign archives for macos
-      id: sign-archives-macos
+      id: sign-archives
       uses: TheQtCompanyRnD/SignArchives@v1
       with:
         macos: ${{ steps.vars.outputs.unsigned_macos_archive }}
-        jenkins-url: '${{ secrets.JENKINS_URL }}'
-        jenkins-user: '${{ secrets.JENKINS_USERNAME }}'
-        jenkins-token: '${{ secrets.JENKINS_TOKEN }}'
-
-    - name: Sign archives for windows
-      id: sign-archives-win
-      uses: TheQtCompanyRnD/SignArchives@v1
-      with:
         win-x64: ${{ steps.vars.outputs.unsigned_windows_archive }}
         jenkins-url: '${{ secrets.JENKINS_URL }}'
         jenkins-user: '${{ secrets.JENKINS_USERNAME }}'
@@ -289,17 +280,25 @@ jobs:
           rm -rf tmp
         }
 
-        repack ${{ steps.sign-archives-macos.outputs.macos }} \
+        repack ${{ steps.sign-archives.outputs.macos }} \
           weekly_release/to_be_uploaded/qmlls-macos-${{ steps.vars.outputs.revision }}.zip
-        repack ${{ steps.sign-archives-win.outputs.win-x64 }} \
+        repack ${{ steps.sign-archives.outputs.win-x64 }} \
           weekly_release/to_be_uploaded/qmlls-windows-${{ steps.vars.outputs.revision }}.zip
 
         mv weekly_release/*/qmlls-ubuntu-${{ steps.vars.outputs.revision }}.zip \
           weekly_release/to_be_uploaded/qmlls-ubuntu-${{ steps.vars.outputs.revision }}.zip
         mv weekly_release/*/*-debugsymbols.zip weekly_release/to_be_uploaded/
 
+    - name: Upload signed artefact
+      uses: actions/upload-artifact@v4
+      with:
+        path: |
+          weekly_release/to_be_uploaded/qmlls-macos-${{ steps.vars.outputs.revision }}.zip
+          weekly_release/to_be_uploaded/qmlls-windows-${{ steps.vars.outputs.revision }}.zip
+        name: signed-artefacts.zip
+
     - name: Create nightly release
-      if: ${{ ! contains(github.ref, 'tags/qmlls-') }}
+      if: ${{ github.ref == 'refs/heads/main' }}
       uses: softprops/action-gh-release@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -133,7 +133,7 @@ jobs:
         git submodule foreach --recursive git gc --auto # try to save some disk space
         cd qtdeclarative
         git reset --hard origin/dev
-        git fetch https://codereview.qt-project.org/qt/qtdeclarative refs/changes/41/617341/3 && git cherry-pick FETCH_HEAD # TODO: remove me once patch got merged
+        git fetch https://codereview.qt-project.org/qt/qtdeclarative refs/changes/41/617341/4 && git checkout FETCH_HEAD # TODO: remove me once patch got merged
 
     - name: set qtdeclarative to dev and set dependencies via dependencies.yaml
       if: steps.cache_artefacts.outputs.cache-hit != 'true'
@@ -141,7 +141,7 @@ jobs:
       run: | 
         cmake -DSYNC_TO_MODULE="qtdeclarative" -DSYNC_TO_BRANCH="dev" -P cmake/QtSynchronizeRepo.cmake
         (cd qttools; git checkout dev; git pull; git submodule update;)
-        (cd qtdeclarative; git fetch https://codereview.qt-project.org/qt/qtdeclarative refs/changes/41/617341/3 && git cherry-pick FETCH_HEAD) # TODO: remove me once patch got merged
+        (cd qtdeclarative; git fetch https://codereview.qt-project.org/qt/qtdeclarative refs/changes/41/617341/4 && git checkout FETCH_HEAD) # TODO: remove me once patch got merged
         echo "Using following SHAs: "
         for i in . qtdeclarative qtbase qtimageformats qtlanguageserver qtshadertools qtsvg qttools; do (cd $i; echo "$i: $(git show HEAD -s --format=oneline)";); done;
 

--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -69,7 +69,10 @@ jobs:
 
     - name: prepare Linux
       if: runner.os == 'Linux' && steps.cache_artefacts.outputs.cache-hit != 'true'
-      run: sudo apt-get update
+      run: |
+        sudo apt-get update
+        # try to make more disk space by removing unused things
+        rm -rf /usr/local/lib/android/sdk;
     - name: prepare macOS
       if: runner.os == 'macOS' && steps.cache_artefacts.outputs.cache-hit != 'true'
       run: echo noop
@@ -121,34 +124,39 @@ jobs:
       working-directory: source
       run: |
         git fetch
+        git submodule foreach --recursive git gc --auto # try to save some disk space
         cd qtdeclarative
         git reset --hard origin/dev
+        git fetch https://codereview.qt-project.org/qt/qtdeclarative refs/changes/41/617341/3 && git cherry-pick FETCH_HEAD # TODO: remove me once patch got merged
 
     - name: set qtdeclarative to dev and set dependencies via dependencies.yaml
       if: steps.cache_artefacts.outputs.cache-hit != 'true'
       working-directory: source
       run: | 
         cmake -DSYNC_TO_MODULE="qtdeclarative" -DSYNC_TO_BRANCH="dev" -P cmake/QtSynchronizeRepo.cmake
-        echo "Using following SHAs: "
-        for i in . qtdeclarative qtbase qtimageformats qtlanguageserver qtshadertools qtsvg; do (cd $i; echo "$i: $(git show HEAD -s --format=oneline)";); done;
         (cd qttools; git checkout dev; git pull; git submodule update;)
+        echo "Using following SHAs: "
+        for i in . qtdeclarative qtbase qtimageformats qtlanguageserver qtshadertools qtsvg qttools; do (cd $i; echo "$i: $(git show HEAD -s --format=oneline)";); done;
 
     - name: configure and build Qt
       if: steps.cache_artefacts.outputs.cache-hit != 'true'
       run:  |
-        mkdir qt-build
+        rm -rf qt-build: mkdir qt-build
         cd qt-build
         ../source/configure -force-debug-info -ccache -no-pch -release -static -no-icu \
           -force-bundled-libs -submodules qtdeclarative,qttools -nomake tests -nomake examples \
           -prefix '${{ runner.temp }}'/install_dir -no-sbom ${{ matrix.configure_flags }}
         ninja qtdeclarative qtbase qttools
 
+    - uses: actions/checkout@v4
+      path: source
+
     - name: configure and build Qmlls
       if: steps.cache_artefacts.outputs.cache-hit != 'true'
       run:  |
-        mkdir qmlls-build
+        rm -rf qmlls-build; mkdir qmlls-build
         cd qmlls-build
-        ../qt-build/qtbase/bin/qt-cmake -S .. -B . -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo ${{ matrix.qmlls_configure_flags }}
+        ../qt-build/qtbase/bin/qt-cmake -S ../source -B . -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo ${{ matrix.qmlls_configure_flags }}
         ninja
 
     - name: Create info file

--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -31,7 +31,7 @@ jobs:
             tools: ccache
             install_cmd: HOMEBREW_NO_INSTALL_CLEANUP=1 brew install
             configure_flags: "-- '-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64'"
-            qmlls_configure_flags: "'-DCMAKE_OSX_ARCHITECTURES='x86_64;arm64'"
+            qmlls_configure_flags: "'-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64'"
             debugging_symbols_extension: .dSYM
             unsigned_suffix: -unsigned
           - name: windows
@@ -73,11 +73,14 @@ jobs:
       run: |
         sudo apt-get update
         # try to make more disk space by removing unused things
-        apt list --installed || true # if more stuff needs to be removed
+        # apt list --installed || true # if more stuff needs to be removed
+        echo List of installed packages:
+        dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -rn
         pip --list || true # if more stuff needs to be removed
-        sudo apt-get purge firefox chromium-browser microsoft-edge-stable google-chrome-stable || true
+        sudo apt-get purge firefox chromium-browser microsoft-edge-stable google-chrome-stable apache2 mysql-server mysql-common "php*" "ruby*"  || true
         sudo apt-get autoremove || true
         sudo rm -rf /usr/local/lib/android/sdk || true
+        sudo apt-get clean || true
 
     - name: prepare macOS
       if: runner.os == 'macOS' && steps.cache_artefacts.outputs.cache-hit != 'true'
@@ -189,6 +192,10 @@ jobs:
         cd qmlls-build
         ../qt-build/qtbase/bin/qt-cmake${{ matrix.script_extension }} -S ../qmlls-workflow-source -B . -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo ${{ matrix.qmlls_configure_flags }}
         ninja
+
+    - name: Remove Qt Build to save disk space
+      if: steps.cache_artefacts.outputs.cache-hit != 'true'
+      run: rm -rf qt-build
 
     - name: Create info file
       if: steps.cache_artefacts.outputs.cache-hit != 'true'

--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -138,14 +138,14 @@ jobs:
         git reset --hard origin/dev
         git fetch https://codereview.qt-project.org/qt/qtdeclarative refs/changes/41/617341/4 && git checkout FETCH_HEAD # TODO: remove me once patch got merged
         cd ../qttools
-        git fetch https://codereview.qt-project.org/qt/qttools refs/changes/33/619233/3 && git checkout FETCH_HEAD # TODO: remove me once patch got merged
+        git fetch https://codereview.qt-project.org/qt/qttools refs/changes/33/619233/5 && git checkout FETCH_HEAD # TODO: remove me once patch got merged
 
     - name: set qtdeclarative to dev and set dependencies via dependencies.yaml
       if: steps.cache_artefacts.outputs.cache-hit != 'true'
       working-directory: source
       run: | 
         cmake -DSYNC_TO_MODULE="qtdeclarative" -DSYNC_TO_BRANCH="dev" -P cmake/QtSynchronizeRepo.cmake
-        (cd qttools; git checkout dev; git pull; git submodule update; git fetch https://codereview.qt-project.org/qt/qttools refs/changes/33/619233/3 && git checkout FETCH_HEAD) # TODO: remove me once patch got merged
+        (cd qttools; git checkout dev; git pull; git submodule update; git fetch https://codereview.qt-project.org/qt/qttools refs/changes/33/619233/5 && git checkout FETCH_HEAD) # TODO: remove me once patch got merged
         
         (cd qtdeclarative; git fetch https://codereview.qt-project.org/qt/qtdeclarative refs/changes/41/617341/4 && git checkout FETCH_HEAD) # TODO: remove me once patch got merged
         echo "Using following SHAs: "
@@ -173,8 +173,8 @@ jobs:
         cd qt-build
         ../source/configure -force-debug-info -ccache -no-pch -release -static -no-icu \
           -force-bundled-libs -submodules qtdeclarative,qttools -nomake tests -nomake examples \
-          -no-prefix -no-sbom -feature-qthelpheadless ${{ matrix.configure_flags }}
-        ninja qtdeclarative qtbase QHelpEnginePlugin
+          -no-prefix -no-sbom -no-gui ${{ matrix.configure_flags }}
+        ninja qtdeclarative qtbase Tools QHelpEnginePlugin_init QHelpEnginePlugin
 
     - name: save qt build cache ### TODO: to be removed before merging into dev
       if: always() && steps.cache_qt_build.outputs.cache-hit != 'true'

--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -140,7 +140,7 @@ jobs:
 
     - name: cache qt build ### TODO: to be removed before merging into dev
       id: cache_qt_build
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       if: steps.cache_artefacts.outputs.cache-hit != 'true'
       with:
         path: qt-build
@@ -155,6 +155,13 @@ jobs:
           -force-bundled-libs -submodules qtdeclarative,qttools -nomake tests -nomake examples \
           -no-prefix -no-sbom ${{ matrix.configure_flags }}
         ninja qtdeclarative qtbase qttools
+
+    - name: save qt build cache ### TODO: to be removed before merging into dev
+      if: always() && steps.cache_qt_build.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: qt-build
+        key: ${{ runner.os }}-qt5build
 
     - uses: actions/checkout@v4
       if: steps.cache_artefacts.outputs.cache-hit != 'true'

--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -130,16 +130,15 @@ jobs:
       run: |
         git fetch
         git submodule foreach --recursive git gc --auto # try to save some disk space
-        cd qtdeclarative
-        git reset --hard origin/dev
-        (cd ../qttools; git checkout dev; git reset --hard origin/dev; git submodule update)
+        (cd qtdeclarative; git reset --hard origin/dev;)
+        (cd qttools; git checkout dev; git reset --hard origin/dev; git submodule update)
 
     - name: set qtdeclarative to dev and set dependencies via dependencies.yaml
       if: steps.cache_artefacts.outputs.cache-hit != 'true'
       working-directory: source
       run: | 
         cmake -DSYNC_TO_MODULE="qtdeclarative" -DSYNC_TO_BRANCH="dev" -P cmake/QtSynchronizeRepo.cmake
-        (cd ../qttools; git checkout dev; git reset --hard origin/dev; git submodule update)
+        (cd qttools; git checkout dev; git reset --hard origin/dev; git submodule update)
         
         echo "Using following SHAs: "
         for i in . qtdeclarative qtbase qtimageformats qtlanguageserver qtshadertools qtsvg qttools; do (cd $i; echo "$i: $(git show HEAD -s --format=oneline)";); done;

--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -136,7 +136,6 @@ jobs:
         git submodule foreach --recursive git gc --auto # try to save some disk space
         cd qtdeclarative
         git reset --hard origin/dev
-        git fetch https://codereview.qt-project.org/qt/qtdeclarative refs/changes/41/617341/4 && git checkout FETCH_HEAD # TODO: remove me once patch got merged
         (cd ../qttools; git checkout dev; git reset --hard origin/dev; git submodule update)
 
     - name: set qtdeclarative to dev and set dependencies via dependencies.yaml
@@ -146,7 +145,6 @@ jobs:
         cmake -DSYNC_TO_MODULE="qtdeclarative" -DSYNC_TO_BRANCH="dev" -P cmake/QtSynchronizeRepo.cmake
         (cd ../qttools; git checkout dev; git reset --hard origin/dev; git submodule update)
         
-        (cd qtdeclarative; git fetch https://codereview.qt-project.org/qt/qtdeclarative refs/changes/41/617341/4 && git checkout FETCH_HEAD) # TODO: remove me once patch got merged
         echo "Using following SHAs: "
         for i in . qtdeclarative qtbase qtimageformats qtlanguageserver qtshadertools qtsvg qttools; do (cd $i; echo "$i: $(git show HEAD -s --format=oneline)";); done;
 

--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -149,7 +149,8 @@ jobs:
         ninja qtdeclarative qtbase qttools
 
     - uses: actions/checkout@v4
-      path: source
+      with:
+        path: source
 
     - name: configure and build Qmlls
       if: steps.cache_artefacts.outputs.cache-hit != 'true'

--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -106,7 +106,7 @@ jobs:
 
     - name: cache repository
       id: cache-repo
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       if: steps.cache_artefacts.outputs.cache-hit != 'true'
       with:
         path: source
@@ -137,6 +137,13 @@ jobs:
         (cd qttools; git checkout dev; git pull; git submodule update;)
         echo "Using following SHAs: "
         for i in . qtdeclarative qtbase qtimageformats qtlanguageserver qtshadertools qtsvg qttools; do (cd $i; echo "$i: $(git show HEAD -s --format=oneline)";); done;
+
+    - name: save cached repository
+      if: always() && steps.cache_artefacts.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: source
+        key: ${{ runner.os }}-qt5repo
 
     - name: cache qt build ### TODO: to be removed before merging into dev
       id: cache_qt_build

--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -137,13 +137,16 @@ jobs:
         cd qtdeclarative
         git reset --hard origin/dev
         git fetch https://codereview.qt-project.org/qt/qtdeclarative refs/changes/41/617341/4 && git checkout FETCH_HEAD # TODO: remove me once patch got merged
+        cd ../qttools
+        git fetch https://codereview.qt-project.org/qt/qttools refs/changes/33/619233/3 && git checkout FETCH_HEAD # TODO: remove me once patch got merged
 
     - name: set qtdeclarative to dev and set dependencies via dependencies.yaml
       if: steps.cache_artefacts.outputs.cache-hit != 'true'
       working-directory: source
       run: | 
         cmake -DSYNC_TO_MODULE="qtdeclarative" -DSYNC_TO_BRANCH="dev" -P cmake/QtSynchronizeRepo.cmake
-        (cd qttools; git checkout dev; git pull; git submodule update;)
+        (cd qttools; git checkout dev; git pull; git submodule update; git fetch https://codereview.qt-project.org/qt/qttools refs/changes/33/619233/3 && git checkout FETCH_HEAD) # TODO: remove me once patch got merged
+        
         (cd qtdeclarative; git fetch https://codereview.qt-project.org/qt/qtdeclarative refs/changes/41/617341/4 && git checkout FETCH_HEAD) # TODO: remove me once patch got merged
         echo "Using following SHAs: "
         for i in . qtdeclarative qtbase qtimageformats qtlanguageserver qtshadertools qtsvg qttools; do (cd $i; echo "$i: $(git show HEAD -s --format=oneline)";); done;
@@ -170,8 +173,8 @@ jobs:
         cd qt-build
         ../source/configure -force-debug-info -ccache -no-pch -release -static -no-icu \
           -force-bundled-libs -submodules qtdeclarative,qttools -nomake tests -nomake examples \
-          -no-prefix -no-sbom ${{ matrix.configure_flags }}
-        ninja qtdeclarative qtbase qttools
+          -no-prefix -no-sbom -feature-qthelpheadless ${{ matrix.configure_flags }}
+        ninja qtdeclarative qtbase QHelpEnginePlugin
 
     - name: save qt build cache ### TODO: to be removed before merging into dev
       if: always() && steps.cache_qt_build.outputs.cache-hit != 'true'

--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -30,8 +30,8 @@ jobs:
             deps:
             tools: ccache
             install_cmd: HOMEBREW_NO_INSTALL_CLEANUP=1 brew install
-            configure_flags: -- '-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64'
-            qmlls_configure_flags: \'-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64\'
+            configure_flags: "-- '-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64'"
+            qmlls_configure_flags: "'-DCMAKE_OSX_ARCHITECTURES='x86_64;arm64'"
             debugging_symbols_extension: .dSYM
             unsigned_suffix: -unsigned
           - name: windows
@@ -213,8 +213,8 @@ jobs:
       if: steps.cache_artefacts.outputs.cache-hit != 'true'
       run: |
         mkdir artefacts
-        7z a artefacts/${{ steps.artefacts_cache_key.outputs.artefact_basename }}-debugsymbols.zip ./qmlls-build/qtbase/bin/qmlls${{ matrix.debugging_symbols_extension }} info.txt
-        7z a artefacts/${{ steps.artefacts_cache_key.outputs.artefact_basename }}${{ matrix.unsigned_suffix }}.zip ./qmlls-build/qtbase/bin/qmlls${{ matrix.executable_extension }} info.txt
+        7z a artefacts/${{ steps.artefacts_cache_key.outputs.artefact_basename }}-debugsymbols.zip ./qmlls-build/qmlls${{ matrix.debugging_symbols_extension }} info.txt
+        7z a artefacts/${{ steps.artefacts_cache_key.outputs.artefact_basename }}${{ matrix.unsigned_suffix }}.zip ./qmlls-build/qmlls${{ matrix.executable_extension }} info.txt
 
     - name: Upload artefact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -31,7 +31,7 @@ jobs:
             tools: ccache
             install_cmd: HOMEBREW_NO_INSTALL_CLEANUP=1 brew install
             configure_flags: -- '-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64'
-            qmlls_configure_flags: '-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64'
+            qmlls_configure_flags: \'-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64\'
             debugging_symbols_extension: .dSYM
             unsigned_suffix: -unsigned
           - name: windows

--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -31,7 +31,7 @@ jobs:
             tools: ccache
             install_cmd: HOMEBREW_NO_INSTALL_CLEANUP=1 brew install
             configure_flags: -- '-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64'
-            qmlls_configure_flags: -DCMAKE_OSX_ARCHITECTURES=x86_64;arm64
+            qmlls_configure_flags: '-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64'
             debugging_symbols_extension: .dSYM
             unsigned_suffix: -unsigned
           - name: windows
@@ -42,6 +42,7 @@ jobs:
             configure_flags: -no-feature-sql-psql -no-feature-sql-mysql -no-feature-sql-odbc
             debugging_symbols_extension: .pdb
             executable_extension: .exe
+            script_extension: .bat
             unsigned_suffix: -unsigned
     runs-on: ${{ matrix.os }}
 
@@ -72,7 +73,12 @@ jobs:
       run: |
         sudo apt-get update
         # try to make more disk space by removing unused things
-        sudo rm -rf /usr/local/lib/android/sdk
+        apt list --installed || true # if more stuff needs to be removed
+        pip --list || true # if more stuff needs to be removed
+        sudo apt-get purge firefox chromium-browser microsoft-edge-stable google-chrome-stable || true
+        sudo apt-get autoremove || true
+        sudo rm -rf /usr/local/lib/android/sdk || true
+
     - name: prepare macOS
       if: runner.os == 'macOS' && steps.cache_artefacts.outputs.cache-hit != 'true'
       run: echo noop
@@ -135,6 +141,7 @@ jobs:
       run: | 
         cmake -DSYNC_TO_MODULE="qtdeclarative" -DSYNC_TO_BRANCH="dev" -P cmake/QtSynchronizeRepo.cmake
         (cd qttools; git checkout dev; git pull; git submodule update;)
+        (cd qtdeclarative; git fetch https://codereview.qt-project.org/qt/qtdeclarative refs/changes/41/617341/3 && git cherry-pick FETCH_HEAD) # TODO: remove me once patch got merged
         echo "Using following SHAs: "
         for i in . qtdeclarative qtbase qtimageformats qtlanguageserver qtshadertools qtsvg qttools; do (cd $i; echo "$i: $(git show HEAD -s --format=oneline)";); done;
 
@@ -180,7 +187,7 @@ jobs:
       run:  |
         rm -rf qmlls-build; mkdir qmlls-build
         cd qmlls-build
-        ../qt-build/qtbase/bin/qt-cmake -S ../qmlls-workflow-source -B . -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo ${{ matrix.qmlls_configure_flags }}
+        ../qt-build/qtbase/bin/qt-cmake${{ matrix.script_extension }} -S ../qmlls-workflow-source -B . -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo ${{ matrix.qmlls_configure_flags }}
         ninja
 
     - name: Create info file

--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -141,7 +141,7 @@ jobs:
     - name: configure and build Qt
       if: steps.cache_artefacts.outputs.cache-hit != 'true'
       run:  |
-        rm -rf qt-build: mkdir qt-build
+        rm -rf qt-build; mkdir qt-build
         cd qt-build
         ../source/configure -force-debug-info -ccache -no-pch -release -static -no-icu \
           -force-bundled-libs -submodules qtdeclarative,qttools -nomake tests -nomake examples \

--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -158,14 +158,6 @@ jobs:
         path: source
         key: ${{ runner.os }}-qt5repo
 
-    - name: cache qt build ### TODO: to be removed before merging into dev
-      id: cache_qt_build
-      uses: actions/cache/restore@v4
-      if: steps.cache_artefacts.outputs.cache-hit != 'true'
-      with:
-        path: qt-build
-        key: ${{ runner.os }}-qt5build
-
     - name: configure and build Qt
       if: steps.cache_artefacts.outputs.cache-hit != 'true' && steps.cache_qt_build.outputs.cache-hit != 'true'
       run:  |
@@ -175,13 +167,6 @@ jobs:
           -force-bundled-libs -submodules qtdeclarative,qttools -nomake tests -nomake examples \
           -no-prefix -no-sbom -no-gui ${{ matrix.configure_flags }}
         ninja qtdeclarative qtbase Tools QHelpEnginePlugin_init QHelpEnginePlugin
-
-    - name: save qt build cache ### TODO: to be removed before merging into dev
-      if: always() && steps.cache_qt_build.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
-      with:
-        path: qt-build
-        key: ${{ runner.os }}-qt5build
 
     - uses: actions/checkout@v4
       if: steps.cache_artefacts.outputs.cache-hit != 'true'

--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -138,14 +138,14 @@ jobs:
         git reset --hard origin/dev
         git fetch https://codereview.qt-project.org/qt/qtdeclarative refs/changes/41/617341/4 && git checkout FETCH_HEAD # TODO: remove me once patch got merged
         cd ../qttools
-        git fetch https://codereview.qt-project.org/qt/qttools refs/changes/33/619233/5 && git checkout FETCH_HEAD # TODO: remove me once patch got merged
+        git fetch https://codereview.qt-project.org/qt/qttools refs/changes/33/619233/7 && git checkout FETCH_HEAD # TODO: remove me once patch got merged
 
     - name: set qtdeclarative to dev and set dependencies via dependencies.yaml
       if: steps.cache_artefacts.outputs.cache-hit != 'true'
       working-directory: source
       run: | 
         cmake -DSYNC_TO_MODULE="qtdeclarative" -DSYNC_TO_BRANCH="dev" -P cmake/QtSynchronizeRepo.cmake
-        (cd qttools; git checkout dev; git pull; git submodule update; git fetch https://codereview.qt-project.org/qt/qttools refs/changes/33/619233/5 && git checkout FETCH_HEAD) # TODO: remove me once patch got merged
+        (cd qttools; git checkout dev; git pull; git submodule update; git fetch https://codereview.qt-project.org/qt/qttools refs/changes/33/619233/7 && git checkout FETCH_HEAD) # TODO: remove me once patch got merged
         
         (cd qtdeclarative; git fetch https://codereview.qt-project.org/qt/qtdeclarative refs/changes/41/617341/4 && git checkout FETCH_HEAD) # TODO: remove me once patch got merged
         echo "Using following SHAs: "

--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -145,7 +145,7 @@ jobs:
         cd qt-build
         ../source/configure -force-debug-info -ccache -no-pch -release -static -no-icu \
           -force-bundled-libs -submodules qtdeclarative,qttools -nomake tests -nomake examples \
-          -prefix '${{ runner.temp }}'/install_dir -no-sbom ${{ matrix.configure_flags }}
+          -no-prefix -no-sbom ${{ matrix.configure_flags }}
         ninja qtdeclarative qtbase qttools
 
     - uses: actions/checkout@v4

--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -191,7 +191,7 @@ jobs:
         rm -rf qmlls-build; mkdir qmlls-build
         cd qmlls-build
         ../qt-build/qtbase/bin/qt-cmake${{ matrix.script_extension }} -S ../qmlls-workflow-source -B . -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo ${{ matrix.qmlls_configure_flags }}
-        ninja
+        ninja -v
 
     - name: Remove Qt Build to save disk space
       if: steps.cache_artefacts.outputs.cache-hit != 'true'
@@ -266,11 +266,19 @@ jobs:
         echo Files to be signed: ${unsigned_macos_archive} and ${unsigned_windows_archive}
         ls -lh ${unsigned_windows_archive} ${unsigned_macos_archive}
 
-    - name: Sign archives
-      id: sign-archives
+    - name: Sign archives for macos
+      id: sign-archives-macos
       uses: TheQtCompanyRnD/SignArchives@v1
       with:
         macos: ${{ steps.vars.outputs.unsigned_macos_archive }}
+        jenkins-url: '${{ secrets.JENKINS_URL }}'
+        jenkins-user: '${{ secrets.JENKINS_USERNAME }}'
+        jenkins-token: '${{ secrets.JENKINS_TOKEN }}'
+
+    - name: Sign archives for windows
+      id: sign-archives-win
+      uses: TheQtCompanyRnD/SignArchives@v1
+      with:
         win-x64: ${{ steps.vars.outputs.unsigned_windows_archive }}
         jenkins-url: '${{ secrets.JENKINS_URL }}'
         jenkins-user: '${{ secrets.JENKINS_USERNAME }}'
@@ -293,9 +301,9 @@ jobs:
           rm -rf tmp
         }
 
-        repack ${{ steps.sign-archives.outputs.macos }} \
+        repack ${{ steps.sign-archives-macos.outputs.macos }} \
           weekly_release/to_be_uploaded/qmlls-macos-${{ steps.vars.outputs.revision }}.zip
-        repack ${{ steps.sign-archives.outputs.win-x64 }} \
+        repack ${{ steps.sign-archives-win.outputs.win-x64 }} \
           weekly_release/to_be_uploaded/qmlls-windows-${{ steps.vars.outputs.revision }}.zip
 
         mv weekly_release/*/qmlls-ubuntu-${{ steps.vars.outputs.revision }}.zip \

--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -264,8 +264,7 @@ jobs:
         echo unsigned_windows_archive=${unsigned_windows_archive} >> $GITHUB_OUTPUT
 
         echo Files to be signed: ${unsigned_macos_archive} and ${unsigned_windows_archive}
-        ls -lh ${unsigned_windows_archive}
-        du -lh ${unsigned_macos_archive}
+        ls -lh ${unsigned_windows_archive} ${unsigned_macos_archive}
 
     - name: Sign archives
       id: sign-archives

--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -138,8 +138,16 @@ jobs:
         echo "Using following SHAs: "
         for i in . qtdeclarative qtbase qtimageformats qtlanguageserver qtshadertools qtsvg qttools; do (cd $i; echo "$i: $(git show HEAD -s --format=oneline)";); done;
 
-    - name: configure and build Qt
+    - name: cache qt build ### TODO: to be removed before merging into dev
+      id: cache_qt_build
+      uses: actions/cache@v4
       if: steps.cache_artefacts.outputs.cache-hit != 'true'
+      with:
+        path: qt-build
+        key: ${{ runner.os }}-qt5build
+
+    - name: configure and build Qt
+      if: steps.cache_artefacts.outputs.cache-hit != 'true' && steps.cache_qt_build.outputs.cache-hit != 'true'
       run:  |
         rm -rf qt-build; mkdir qt-build
         cd qt-build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright (C) 2024 The Qt Company Ltd.
+# SPDX-License-Identifier: BSD-3-Clause
+
+cmake_minimum_required(VERSION 3.16)
+
+project(qmlls VERSION 0.1 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(Qt6 REQUIRED COMPONENTS QmlLSPrivate QmlCompiler QmlToolingSettingsPrivate Help)
+
+qt_standard_project_setup(REQUIRES 6.8)
+
+qt_add_executable(qmlls WIN32 qmllanguageservertool.cpp)
+
+target_link_libraries(qmlls
+    PRIVATE
+        Qt::QmlLSPrivate
+        Qt::Help
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,12 +6,30 @@ cmake_minimum_required(VERSION 3.16)
 project(qmlls VERSION 0.1 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(QT_NO_EXCEPTIONS ON)
 
-find_package(Qt6 REQUIRED COMPONENTS QmlLSPrivate QmlCompiler QmlToolingSettingsPrivate Help)
+find_package(Qt6 REQUIRED COMPONENTS QmlLSPrivate Help BuildInternals)
 
 qt_standard_project_setup(REQUIRES 6.8)
 
 qt_add_executable(qmlls WIN32 qmllanguageservertool.cpp)
+
+# keep binary size of qmlls small, exclude plugins that are not needed
+qt_import_plugins(qmlls
+    EXCLUDE_BY_TYPE
+        imageformats
+        iconengines
+        qmltooling
+        styles
+        networkaccess
+        networkinformation
+        tls
+        qmlmeta
+        qmlworkerscript
+        qmlmodels
+        quick
+        qml_plugin
+        platforms)
 
 target_link_libraries(qmlls
     PRIVATE

--- a/qmllanguageservertool.cpp
+++ b/qmllanguageservertool.cpp
@@ -1,0 +1,33 @@
+// Copyright (C) 2021 The Qt Company Ltd.
+// SPDX-License-Identifier: LicenseRef-Qt-Commercial OR GPL-3.0-only WITH Qt-GPL-exception-1.0
+
+#include <private/qmllsmain_p.h>
+
+// To debug:
+//
+// * simple logging can be redirected to a file
+//   passing -l <file> to the qmlls command
+//
+// * more complex debugging can use named pipes:
+//
+//     mkfifo qmllsIn
+//     mkfifo qmllsOut
+//
+// this together with a qmllsEcho script that can be defined as
+//
+//     #!/bin/sh
+//     cat -u < ~/qmllsOut &
+//     cat -u > ~/qmllsIn
+//
+// allows to use qmllsEcho as lsp server, and still easily start
+// it in a terminal
+//
+//     qmlls < ~/qmllsIn > ~/qmllsOut
+//
+// * statup can be slowed down to have the time to attach via the
+//   -w <nSeconds> flag.
+
+int main(int argv, char *argc[])
+{
+    return QmlLsp::qmllsMain(argv, argc);
+}


### PR DESCRIPTION
The documentation plugin lives in qttools, but qmlls lives in qtdeclarative.

Add a clone version of qmlls (which is nowadays only a minimal entry point into the qmlls library inside qtdeclarative) outside of the qt repo so that the documentation plugin QHelpEnginePlugin can be statically linked into it.

Building qt takes up more space, such that the ubuntu runner needs to remove some of the unused pre-installed stuff to not run into disk space error during building.

Build qt with "-no-gui" to avoid getting the Qt::Gui dependency inside QHelpEnginePlugin and qmlls, as it blows the binary size of qmlls up.

Rename the artefact cache because they will need to be purged anyway with this merge.