### PR TITLE
Move back to ubuntu 22.04

### DIFF
--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         include:
           - name: ubuntu
-            os:   ubuntu-latest
+            os:   ubuntu-22.04
             deps: libgl-dev libglu-dev 'libxcb*-dev' libx11-xcb-dev libxkbcommon-x11-dev libb2-dev libdouble-conversion-dev
             tools: ccache
             install_cmd: sudo apt-get -y install


### PR DESCRIPTION
It seems that Ubuntu 20 is almost out of support, and binaries compiled on ubuntu 24 are not compatible on ubuntu 22 because of glibc version dependencies. Therefore, compile on ubuntu 22 instead of "latest".