### PR TITLE
Arm binaries

### DIFF
--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -43,7 +43,7 @@ jobs:
             debugging_symbols_extension: .pdb
             executable_extension: .exe
             script_extension: .bat
-           unsigned_suffix: -unsigned
+            unsigned_suffix: -unsigned
           - name: ubuntu-arm
             os: ubuntu-22.04-arm
             deps: libgl-dev libglu-dev 'libxcb*-dev' libx11-xcb-dev libxkbcommon-x11-dev libb2-dev libdouble-conversion-dev


### PR DESCRIPTION
Add arm binaries for ubuntu and windows. Add a "x64" to the non-arm binaries, to differentiate them from the "arm64" binaries. Note that the macos binaries are universal (and run on both arm and x64 processors).