### PR TITLE
Fix linux build

### DIFF
--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -24,7 +24,7 @@ jobs:
         include:
           - name: linux-x64
             os:   ubuntu-22.04
-            deps: libgl-dev libglu-dev 'libxcb*-dev' libx11-xcb-dev libxkbcommon-x11-dev libb2-dev libdouble-conversion-dev libpq5=14.19-0ubuntu0.22.04.1
+            deps: libgl-dev libglu-dev 'libxcb*-dev' libx11-xcb-dev libxkbcommon-x11-dev libb2-dev libdouble-conversion-dev libpq5=14.20-0ubuntu0.22.04.1
             tools: ccache
             install_cmd: sudo apt-get --allow-downgrades -y install
             configure_flags: -xcb

--- a/.github/workflows/build_qmlls.yaml
+++ b/.github/workflows/build_qmlls.yaml
@@ -142,6 +142,7 @@ jobs:
     - name: cloning qt5 and initialize subrepositories
       if: steps.cache-repo.outputs.cache-hit != 'true' && steps.cache_artifacts.outputs.cache-hit != 'true'
       run:  |
+        rm -rf source
         git clone "https://codereview.qt-project.org/qt/qt5" source
         cd source
         ./init-repository --module-subset=qtdeclarative,qttools


### PR DESCRIPTION
The libpq5 14.19 version does not seem to exist in the ubuntu repo anymore, so update it to 14.20. Note that 14.19 was required for ubuntu 20 users, but ubuntu 20 is end of life since 6 months already, so we should be able to update the version without breaking qmlls for ubuntu users.